### PR TITLE
Add an options collections to models.

### DIFF
--- a/docker_etude/models/base.py
+++ b/docker_etude/models/base.py
@@ -5,8 +5,13 @@ Common model behavior.
 from abc import ABC, abstractclassmethod, abstractmethod
 from collections import OrderedDict
 
+from docker_etude.models.options import Options
+
 
 class Model(ABC):
+
+    def __init__(self):
+        self.options = Options()
 
     def to_safe_dict(self):
         """

--- a/docker_etude/models/composition.py
+++ b/docker_etude/models/composition.py
@@ -31,6 +31,7 @@ class Composition(Model):
                  services=None,
                  version="3",
                  volumes=None):
+        super().__init__()
         self.version = version
         self.networks = networks or OrderedDict()
         self.services = services or OrderedDict()

--- a/docker_etude/models/network.py
+++ b/docker_etude/models/network.py
@@ -13,6 +13,7 @@ class Network(Model):
 
     """
     def __init__(self, driver=None, external=None, name=None):
+        super().__init__()
         self.driver = driver
         self.external = external
         self.name = name

--- a/docker_etude/models/options.py
+++ b/docker_etude/models/options.py
@@ -1,0 +1,16 @@
+"""
+A set of user-defined options.
+
+Allows modules to enable contingent behavior on composition models, e.g. based on CLI input.
+
+"""
+
+
+class Options:
+
+    def __getattr__(self, key):
+        """
+        Return None for missing attribute.
+
+        """
+        return None

--- a/docker_etude/models/service.py
+++ b/docker_etude/models/service.py
@@ -36,6 +36,7 @@ class Service(Model):
         :param name: the service's name in the composition definition (strongly encouraged)
 
         """
+        super().__init__()
         self.name = name
         self.image = image
         self.command = command

--- a/docker_etude/models/volume.py
+++ b/docker_etude/models/volume.py
@@ -13,6 +13,7 @@ class Volume(Model):
 
     """
     def __init__(self, driver=None, name=None):
+        super().__init__()
         self.driver = driver
         self.name = name
 

--- a/docker_etude/tests/models/test_options.py
+++ b/docker_etude/tests/models/test_options.py
@@ -1,0 +1,18 @@
+"""
+Test options.
+
+"""
+from hamcrest import assert_that, equal_to, is_, none
+
+from docker_etude.models.options import Options
+
+
+def test_null():
+    options = Options()
+    assert_that(options.foo, is_(none()))
+
+
+def test_set():
+    options = Options()
+    options.foo = "bar"
+    assert_that(options.foo, is_(equal_to("bar")))


### PR DESCRIPTION
For example, every service will now have an `service.options` object, which can be assigned to and will default to `None` for any attribute access.

This makes it simple to write tests like:

```
if service.options.local:
    pass
```

without any special casing.